### PR TITLE
Allows export only on assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ For detail usage, please check the swagger specification in this [link][SwaggerS
 Command                       | Description
 :-----------------------------|:-----------
  `adonis swagger:export`      | Export config file & swagger-ui assets
+ `adonis swagger:export-docs` | Export swagger-ui assets only
  `adonis swagger:remove`      | Remove config file & swagger-ui assets
  `adonis swagger:remove-docs` | Remove swagger-ui only
 

--- a/commands/SwaggerExportDocs.js
+++ b/commands/SwaggerExportDocs.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const { Command } = require('@adonisjs/ace')
+const path = require('path')
+
+class SwaggerExportDocs extends Command {
+  static get signature () {
+    return `
+      swagger:export-docs
+      { --silent : Hide the console log }
+    `
+  }
+
+  static get description () {
+    return 'Export swagger-ui assets only'
+  }
+
+  async handle (args, options) {
+    if (!options.silent) this.info('Exporting assets to public folder (public/docs)')
+    await this.copy(path.join(__dirname, '../templates/docs'), 'public/docs')
+
+    if (!options.silent) this.success(`${this.icon('success')} Completed`)
+  }
+}
+
+module.exports = SwaggerExportDocs

--- a/providers/SwaggerProvider.js
+++ b/providers/SwaggerProvider.js
@@ -19,6 +19,7 @@ class SwaggerProvider extends ServiceProvider {
 
   _registerCommands () {
     this.app.bind('Adonis/Commands/SwaggerExport', () => require('../commands/SwaggerExport'))
+    this.app.bind('Adonis/Commands/SwaggerExportDocs', () => require('../commands/SwaggerExportDocs'))
     this.app.bind('Adonis/Commands/SwaggerRemove', () => require('../commands/SwaggerRemove'))
     this.app.bind('Adonis/Commands/SwaggerRemoveDocs', () => require('../commands/SwaggerRemoveDocs'))
   }
@@ -26,6 +27,7 @@ class SwaggerProvider extends ServiceProvider {
   _addCommands () {
     const ace = require('@adonisjs/ace')
     ace.addCommand('Adonis/Commands/SwaggerExport')
+    ace.addCommand('Adonis/Commands/SwaggerExportDocs')
     ace.addCommand('Adonis/Commands/SwaggerRemove')
     ace.addCommand('Adonis/Commands/SwaggerRemoveDocs')
   }

--- a/test/swagger-provider.spec.js
+++ b/test/swagger-provider.spec.js
@@ -13,12 +13,17 @@ test.group('Swagger provider test', (group) => {
 
     // call in boot SwaggerProvider
     ace.addCommand('Adonis/Commands/SwaggerExport')
+    ace.addCommand('Adonis/Commands/SwaggerExportDocs')
     ace.addCommand('Adonis/Commands/SwaggerRemove')
     ace.addCommand('Adonis/Commands/SwaggerRemoveDocs')
   })
 
   test('Check is swagger:export command available', async (assert) => {
     assert.equal('swagger:export', ioc.use('Adonis/Commands/SwaggerExport')._name)
+  }).timeout(0)
+
+  test('Check is swagger:export-docs command available', async (assert) => {
+    assert.equal('swagger:export', ioc.use('Adonis/Commands/SwaggerExportDocs')._name)
   }).timeout(0)
 
   test('Check is swagger:remove command available', async (assert) => {
@@ -36,6 +41,14 @@ test.group('Swagger provider test', (group) => {
     // check config and docs is exists
     assert.isTrue(isExists(path.join(__dirname, '../public/docs')))
     assert.isTrue(isExists(path.join(__dirname, '../config/swagger.js')))
+  })
+
+  test('Execute swagger:export-docs command test', async (assert) => {
+    // execute command
+    await ace.call('swagger:export-docs', null, { silent: true })
+
+    // check config and docs is exists
+    assert.isTrue(isExists(path.join(__dirname, '../public/docs')))
   })
 
   test('Execute swagger:remove command test', async (assert) => {


### PR DESCRIPTION
You may need to version config.js, and the export will overwrite this file. I registered a new command that exports only the assets.