### PR TITLE
Improve documentation for API-only projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ adonis install adonis-swagger
   ```
 
 * **Note:** For projects that uses API-only blueprint (using `--api-only` flag), please 
-  enable `Adonis/Middleware/Static` middleware in `start/kernel.js`:
+  enable `Adonis/Middleware/Static` under `serverMiddleware` in `start/kernel.js`:
   ```js
   const serverMiddleware = [
     'Adonis/Middleware/Static',

--- a/README.md
+++ b/README.md
@@ -21,15 +21,24 @@ adonis install adonis-swagger
   ]
   ```
 
-* Other configuration please update the `config/swagger.js` file.
+* **Note:** For projects that uses API-only blueprint (using `--api-only` flag), please 
+  enable `Adonis/Middleware/Static` middleware in `start/kernel.js`:
+  ```js
+  const serverMiddleware = [
+    'Adonis/Middleware/Static',
+    ...
+  ]
+  ```
+
+* For other configuration, please update the `config/swagger.js`.
 
 # Sample Usage
-* Add new route
+* Add new route:
   ```js
   Route.get('/api/hello', 'TestController.hello')
   ```
 
-* Create TestController using command adonis make:controller Test
+* Create `TestController` using `adonis make:controller Test` command:
   ```js
   'use strict'
   
@@ -63,7 +72,7 @@ adonis install adonis-swagger
   module.exports = TestController
   ```
 
-* You can also define the schema in the Models
+* You can also define the schema in the Models:
   ```js
   'use strict'
   
@@ -108,18 +117,17 @@ adonis install adonis-swagger
   │       ├── **/*.yml
   ```
 
-* Other sample in YAML and JS format please refer this [link](/sample)
+* For other sample in YAML and JS format, please refer to this [link](/sample).
 
-
-Open http://localhost:3333/docs in your browser, ayeey 🎉 </br>
-For detail usage, please check the swagger specification in this [link][SwaggerSpec].
+Open http://localhost:3333/docs in your browser, ayeey 🎉  
+For detail usage, please check the Swagger specification in this [link][SwaggerSpec].
 
 # Command List
 Command                       | Description
 :-----------------------------|:-----------
- `adonis swagger:export`      | Export config file & swagger-ui assets
- `adonis swagger:remove`      | Remove config file & swagger-ui assets
- `adonis swagger:remove-docs` | Remove swagger-ui only
+ `adonis swagger:export`      | Export config file & `swagger-ui` assets. <br>**Warning: This will reset your `config/swagger.js`!**<br>Please use with caution.
+ `adonis swagger:remove`      | Remove config file & `swagger-ui` assets
+ `adonis swagger:remove-docs` | Remove `swagger-ui` only
 
 # Dependencies
 - [swagger-jsdocs](https://www.npmjs.com/package/swagger-jsdoc)

--- a/instructions.md
+++ b/instructions.md
@@ -1,18 +1,30 @@
-# Registering provider
-```js
-const providers = [
-  ...
-  'adonis-swagger/providers/SwaggerProvider'
-]
-```
+# Configuration
+* Register `SwaggerProvider` in `start/app.js`:
+  ```js
+  const providers = [
+    ...
+    'adonis-swagger/providers/SwaggerProvider'
+  ]
+  ```
+
+* **Note:** For projects that uses API-only blueprint (using `--api-only` flag), please 
+  enable `Adonis/Middleware/Static` middleware in `start/kernel.js`:
+  ```js
+  const serverMiddleware = [
+    'Adonis/Middleware/Static',
+    ...
+  ]
+  ```
+
+* For other configuration, please update the `config/swagger.js`.
 
 # Usage
-* Add new route
+* Add new route:
   ```js
   Route.get('/api/hello', 'TestController.hello')
   ```
 
-* Create TestController using command adonis make:controller Test
+* Create `TestController` using `adonis make:controller Test` command:
   ```js
   'use strict'
   
@@ -46,7 +58,7 @@ const providers = [
   module.exports = TestController
   ```
 
-* You can also define the schema in the Models
+* You can also define the schema in the Models:
   ```js
   'use strict'
   
@@ -93,4 +105,4 @@ const providers = [
 
   > For custom directory, please change the `config/swagger.js` as needed.
 
-* Other sample in YAML and JS format please refer this [link](https://github.com/ahmadarif/adonis-swagger/tree/master/sample)
+* For other sample in YAML and JS format, please refer to this [link](https://github.com/ahmadarif/adonis-swagger/tree/master/sample)

--- a/instructions.md
+++ b/instructions.md
@@ -8,7 +8,7 @@
   ```
 
 * **Note:** For projects that uses API-only blueprint (using `--api-only` flag), please 
-  enable `Adonis/Middleware/Static` middleware in `start/kernel.js`:
+  enable `Adonis/Middleware/Static` under `serverMiddleware` in `start/kernel.js`:
   ```js
   const serverMiddleware = [
     'Adonis/Middleware/Static',


### PR DESCRIPTION
Projects that uses API-only blueprint (using `--api-only` flag) needs to enable `Adonis/Middleware/Static` under `serverMiddleware` in `start/kernel.js`, otherwise the `/docs` URI cannot be accessed.